### PR TITLE
Add generic media type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 docs
 vendor
 *~
+
+#Eclipse files
+/.settings
+/.buildpath
+/.project

--- a/src/Media/Factory/MediaFactory.php
+++ b/src/Media/Factory/MediaFactory.php
@@ -7,6 +7,7 @@ use CanalTP\MediaManager\Media\SoundMedia;
 use CanalTP\MediaManager\Media\PictureMedia;
 use CanalTP\MediaManager\Media\PdfMedia;
 use CanalTP\MediaManager\Media\Factory\MediaFactoryInterface;
+use CanalTP\MediaManager\Media\GenericMedia;
 
 class MediaFactory implements MediaFactoryInterface
 {
@@ -38,7 +39,7 @@ class MediaFactory implements MediaFactoryInterface
                 $this->type = MediaType::PDF;
                 break;
             default:
-                throw new \Exception('MediaManager can be save this type: ' . $this->mime);
+                $this->type = MediaType::UNKNOWN;
         }
     }
 
@@ -56,6 +57,9 @@ class MediaFactory implements MediaFactoryInterface
             case MediaType::PDF:
                 $media = new PdfMedia();
                 break;
+            case MediaType::UNKNOWN:
+            	$media = new GenericMedia();
+            	break;
         }
 
         return ($media);

--- a/src/Media/Factory/MediaFactory.php
+++ b/src/Media/Factory/MediaFactory.php
@@ -58,8 +58,8 @@ class MediaFactory implements MediaFactoryInterface
                 $media = new PdfMedia();
                 break;
             case MediaType::UNKNOWN:
-            	$media = new GenericMedia();
-            	break;
+                $media = new GenericMedia();
+                break;
         }
 
         return ($media);

--- a/src/Media/GenericMedia.php
+++ b/src/Media/GenericMedia.php
@@ -1,0 +1,6 @@
+<?php
+namespace CanalTP\MediaManager\Media;
+
+class GenericMedia extends AbstractMedia
+{
+}

--- a/src/Media/PdfMedia.php
+++ b/src/Media/PdfMedia.php
@@ -2,10 +2,10 @@
 
 namespace CanalTP\MediaManager\Media;
 
-use CanalTP\MediaManager\Media\AbstractMedia;
+use CanalTP\MediaManager\Media\GenericMedia;
 use CanalTP\MediaManager\Media\MediaType;
 
-class PdfMedia extends AbstractMedia
+class PdfMedia extends GenericMedia
 {
     public function __construct()
     {

--- a/src/Media/PictureMedia.php
+++ b/src/Media/PictureMedia.php
@@ -3,10 +3,10 @@
 namespace CanalTP\MediaManager\Media;
 
 use CanalTP\MediaManager\Media\PictureMediaType;
-use CanalTP\MediaManager\Media\AbstractMedia;
+use CanalTP\MediaManager\Media\GenericMedia;
 use CanalTP\MediaManager\Media\MediaType;
 
-class PictureMedia extends AbstractMedia
+class PictureMedia extends GenericMedia
 {
     private $width = null;
     private $length = null;

--- a/src/Media/SoundMedia.php
+++ b/src/Media/SoundMedia.php
@@ -3,10 +3,10 @@
 namespace CanalTP\MediaManager\Media;
 
 use CanalTP\MediaManager\Media\SoundMediaType;
-use CanalTP\MediaManager\Media\AbstractMedia;
+use CanalTP\MediaManager\Media\GenericMedia;
 use CanalTP\MediaManager\Media\MediaType;
 
-class SoundMedia extends AbstractMedia
+class SoundMedia extends GenericMedia
 {
     public function __construct()
     {

--- a/tests/Media/GenericMediaTest.php
+++ b/tests/Media/GenericMediaTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace CanalTP\MediaManager\Test\Media;
+
+use CanalTP\MediaManager\Media\GenericMedia;
+use CanalTP\MediaManager\Media\CanalTP\MediaManager\Media;
+use CanalTP\MediaManager\Media\MediaType;
+
+class GenericMediaTest extends \PHPUnit_Framework_TestCase
+{
+	public function testMediaTypeIsValidForGenericMedia()
+	{
+		$genericMedia = new GenericMedia();
+		$this->assertEquals(MediaType::UNKNOWN, $genericMedia->getMediaType()); 
+	}
+}


### PR DESCRIPTION
The main idea here is to remove the exception when uploading a media of unknown type (eg : plain text files, CSS,...).
A client application may check the media is of expected type by checking the media class returned by the builder rather than catching exception